### PR TITLE
Reformat all non-swift code via npm run fmt

### DIFF
--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/FileOperations.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/FileOperations.java
@@ -13,7 +13,11 @@ public class FileOperations {
 
     public static void DeleteFolderRecursively(File file) throws IOException {
         for (File childFile : file.listFiles()) {
-            if (childFile.isDirectory()) DeleteFolderRecursively(childFile); else childFile.delete();
+            if (childFile.isDirectory()) {
+                DeleteFolderRecursively(childFile);
+            } else {
+                childFile.delete();
+            }
         }
         file.delete();
     }

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeJS.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeJS.java
@@ -57,14 +57,16 @@ public class NodeJS {
 
                     if (nodeLocation == null) nodeLocation = "nodejs";
 
-                    if (nodeLocation.startsWith("./"))
+                    if (nodeLocation.startsWith("./")) {
                         nodeLocation = nodeLocation.substring(2);
-                    else if (nodeLocation.startsWith(".") || nodeLocation.startsWith("/"))
+                    } else if (nodeLocation.startsWith(".") || nodeLocation.startsWith("/")) {
                         nodeLocation = nodeLocation.substring(1);
+                    }
 
-                    if (nodeLocation.endsWith("/"))
+                    if (nodeLocation.endsWith("/")) {
                         nodeLocation = nodeLocation.substring(0, nodeLocation.length() - 1);
-                    
+                    }
+
                     String filesDir = pluginContext.getFilesDir().getAbsolutePath();
                     String nodeFolder = filesDir + "/public/" + nodeLocation;
 
@@ -74,10 +76,11 @@ public class NodeJS {
                     JSONObject packageJSON = new JSONObject(FileOperations.ReadFile(packageFile));
 
                     String mainFile = packageJSON.getString("main");
-                    if (mainFile.startsWith("./"))
+                    if (mainFile.startsWith("./")) {
                         mainFile = mainFile.substring(1);
-                    else if (!mainFile.startsWith("/"))
+                    } else if (!mainFile.startsWith("/")) {
                         mainFile = "/" + mainFile;
+                    }
 
                     String mainPath = nodeFolder + mainFile;
 
@@ -86,7 +89,8 @@ public class NodeJS {
                     e.printStackTrace();
                 }
             }
-        ).start();
+        )
+            .start();
     }
 
     public boolean SendEventMessage(JSONObject data) {
@@ -110,13 +114,12 @@ public class NodeJS {
         try {
             JSONObject data = new JSONObject(message);
 
-            if (channelName.equals("EVENT_CHANNEL"))
+            if (channelName.equals("EVENT_CHANNEL")) {
                 plugin.receive(data);
-            else if (channelName.equals(("APP_CHANNEL"))) {
+            } else if (channelName.equals(("APP_CHANNEL"))) {
                 String event = data.get("event").toString();
 
-                if (event.equals("ready"))
-                    isNodeEngineReady = true;
+                if (event.equals("ready")) isNodeEngineReady = true;
             }
         } catch (JSONException e) {
             // TODO
@@ -128,8 +131,9 @@ public class NodeJS {
         String assetNodeFolder = "public/" + nodeLocation;
 
         File nodeFolderReference = new File(nodeFolder);
-        if (nodeFolderReference.exists() && wasAppUpdated())
+        if (nodeFolderReference.exists() && wasAppUpdated()) {
             FileOperations.DeleteFolderRecursively(nodeFolderReference);
+        }
 
         FileOperations.CopyAssetFolder(pluginContext.getAssets(), assetNodeFolder, nodeFolder);
 

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeJSPlugin.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeJSPlugin.java
@@ -44,16 +44,20 @@ public class NodeJSPlugin extends Plugin {
     public void whenReady(PluginCall call) {
         Timer timer = new Timer();
 
-        timer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                if (NodeJS.isNodeEngineReady) {
-                    call.resolve();
-                    timer.cancel();
-                    timer.purge();
+        timer.scheduleAtFixedRate(
+            new TimerTask() {
+                @Override
+                public void run() {
+                    if (NodeJS.isNodeEngineReady) {
+                        call.resolve();
+                        timer.cancel();
+                        timer.purge();
+                    }
                 }
-            }
-        }, 50, 50);
+            },
+            50,
+            50
+        );
     }
 
     public void receive(JSONObject data) throws JSONException {

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -21,10 +21,13 @@ export class NodeJS extends EventEmitter {
     // Get configurations and start NodeJS engine
     //
     const configFileBase = join(app.getAppPath(), 'capacitor.config.');
-        const configFileExt =
-            existsSync(configFileBase + 'json') ? 'json' :
-                existsSync(configFileBase + 'js') ? 'js' :
-                    existsSync(configFileBase + 'ts') ? 'ts' : undefined;
+    const configFileExt = existsSync(configFileBase + 'json')
+      ? 'json'
+      : existsSync(configFileBase + 'js')
+      ? 'js'
+      : existsSync(configFileBase + 'ts')
+      ? 'ts'
+      : undefined;
 
     if (!configFileExt) startEngine();
 
@@ -35,7 +38,11 @@ export class NodeJS extends EventEmitter {
     });
 
     function startEngine(options: { nodeDir: string } = undefined): void {
-      const nodeDir = join(app.getAppPath(), 'app', options?.nodeDir ?? 'nodejs');
+      const nodeDir = join(
+        app.getAppPath(),
+        'app',
+        options?.nodeDir ?? 'nodejs',
+      );
       const nodePackageJson = join(nodeDir, 'package.json');
       const bridgeModule = join(nodeDir, 'node_modules', 'bridge', 'bridge');
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -8,19 +8,28 @@ export class NodeJSWeb extends WebPlugin {
     super();
 
     // electron platform loads web implementation by default, but native implementation should be used
-    if (typeof CapacitorCustomPlatform !== 'undefined' && CapacitorCustomPlatform?.plugins?.NodeJS)
+    if (
+      typeof CapacitorCustomPlatform !== 'undefined' &&
+      CapacitorCustomPlatform?.plugins?.NodeJS
+    )
       return CapacitorCustomPlatform.plugins.NodeJS;
   }
 
   send(): Promise<{ value: boolean }> {
-    throw this.unavailable('The NodeJS engine is not available in the browser!');
+    throw this.unavailable(
+      'The NodeJS engine is not available in the browser!',
+    );
   }
 
   whenReady(): Promise<void> {
-    throw this.unavailable('The NodeJS engine is not available in the browser!');
+    throw this.unavailable(
+      'The NodeJS engine is not available in the browser!',
+    );
   }
 
   addListener(): Promise<PluginListenerHandle> & PluginListenerHandle {
-    throw this.unavailable('The NodeJS engine is not available in the browser!');
+    throw this.unavailable(
+      'The NodeJS engine is not available in the browser!',
+    );
   }
 }


### PR DESCRIPTION
I don't have MacOS, so I can't run the swift one.

This aligns the formatting with ionic and capacitor coding standards.